### PR TITLE
support tape

### DIFF
--- a/app/buildFilesFromPackageJson.js
+++ b/app/buildFilesFromPackageJson.js
@@ -78,7 +78,7 @@ function createUnitTests(packageJson) {
 }
 
 function getDevDependcyFromScriptName(testScript) {
-  var framework = testScript.match(/^(tap|mocha|grunt|cake)\b/);
+  var framework = testScript.match(/^(tap|tape|mocha|grunt|cake)\b/);
   return framework && framework[1];
 }
 


### PR DESCRIPTION
Adds support for [tape](https://www.npmjs.org/package/tape) test harness. Because your generator is minimalistic, here is the justification: `tape` has 169 dependents, [tap](https://www.npmjs.org/package/tap) has 65.
